### PR TITLE
Update recipe to use conda-build=3 compiler var

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,8 @@ build:
 
 requirements:
   build:
-    - toolchain
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
     - cmake    >=3.3
     - ninja
     - expat    2.1.*


### PR DESCRIPTION
Recommended by the bot in #20, and may help with the CircleCI [build failure there](https://circleci.com/gh/conda-forge/libitk-feedstock/43?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

```
...
Could not find compiler set in environment variable CC:

  gcc.
Call Stack (most recent call first):
  CMakeLists.txt:29 (enable_language)


CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
-- Configuring incomplete, errors occurred!
...
```