### PR TITLE
Revert rerender

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge libitk_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -15,7 +15,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge libitk_dev
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge libitk_dev
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge libitk_dev
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -5,7 +5,7 @@ c_stdlib:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge libitk_dev
+- conda-forge main
 cxx_compiler:
 - vs2019
 fftw:

--- a/README.md
+++ b/README.md
@@ -80,14 +80,14 @@ Current release info
 Installing libitk
 =================
 
-Installing `libitk` from the `conda-forge/label/libitk_dev` channel can be achieved by adding `conda-forge/label/libitk_dev` to your channels with:
+Installing `libitk` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
-conda config --add channels conda-forge/label/libitk_dev
+conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge/label/libitk_dev` channel has been enabled, `libitk, libitk-devel` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `libitk, libitk-devel` can be installed with `conda`:
 
 ```
 conda install libitk libitk-devel
@@ -102,26 +102,26 @@ mamba install libitk libitk-devel
 It is possible to list all of the versions of `libitk` available on your platform with `conda`:
 
 ```
-conda search libitk --channel conda-forge/label/libitk_dev
+conda search libitk --channel conda-forge
 ```
 
 or with `mamba`:
 
 ```
-mamba search libitk --channel conda-forge/label/libitk_dev
+mamba search libitk --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search libitk --channel conda-forge/label/libitk_dev
+mamba repoquery search libitk --channel conda-forge
 
 # List packages depending on `libitk`:
-mamba repoquery whoneeds libitk --channel conda-forge/label/libitk_dev
+mamba repoquery whoneeds libitk --channel conda-forge
 
 # List dependencies of `libitk`:
-mamba repoquery depends libitk --channel conda-forge/label/libitk_dev
+mamba repoquery depends libitk --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   run_exports:
     - {{ pin_subpackage('libitk', min_pin='x.x', max_pin='x.x') }}
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
The smithy render cause the default channel to be libitk_dev, reverting to main.
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
