### PR TITLE
BUG: apply ITK PR #6150 - use check_symbol_exists for TIFFFieldReadCount detection

### DIFF
--- a/recipe/0001-BUG-use-check_symbol_exists-for-TIFFFieldReadCount.patch
+++ b/recipe/0001-BUG-use-check_symbol_exists-for-TIFFFieldReadCount.patch
@@ -1,0 +1,43 @@
+From 811e72e41fb19011b83419565c053d1f6161bfde Mon Sep 17 00:00:00 2001
+From: Bradley Lowekamp <blowekamp@mail.nih.gov>
+Date: Sun, 27 Apr 2026 00:00:00 +0000
+Subject: [PATCH] BUG: Use check_symbol_exists for TIFFFieldReadCount detection
+
+When building with a system TIFF library (ITK_USE_SYSTEM_TIFF=ON), the
+CMake check for TIFFFieldReadCount used check_type_size(), which
+internally calls sizeof() on the argument. Passing a function name to
+sizeof() is non-standard — GCC and Clang accept it as an extension but
+MSVC rejects it — so ITK_TIFF_HAS_TIFFFieldReadCount was never defined
+on Windows builds using an external libTIFF.
+
+Without that define, itkTIFFImageIO falls through to the libtiff
+4.0.0–4.0.2 workaround that directly accesses the internal _TIFFField
+struct. That struct layout is no longer correct for modern libtiff
+versions, causing reads of garbage data and NULL pointer crashes when
+encountering tags with unsupported data types (e.g. an ICC profile tag).
+
+Fixes https://github.com/InsightSoftwareConsortium/ITK/issues/6148
+---
+ Modules/ThirdParty/TIFF/CMakeLists.txt | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+--- a/Modules/ThirdParty/TIFF/CMakeLists.txt
++++ b/Modules/ThirdParty/TIFF/CMakeLists.txt
+@@ -17,9 +17,14 @@ if(ITK_USE_SYSTEM_TIFF)
+   # Check availability of different methods to access TIFF's field
+   # data structure.
+   include(CheckTypeSize)
++  include(CheckSymbolExists)
+   set(CMAKE_REQUIRED_LIBRARIES TIFF::TIFF)
+   set(CMAKE_EXTRA_INCLUDE_FILES "tiffio.h")
+-  check_type_size(TIFFFieldReadCount ITK_TIFF_HAS_TIFFFieldReadCount)
++  # TIFFFieldReadCount is a function, not a type. Using
++  # check_type_size (sizeof) on a function is non-standard and fails
++  # on MSVC, causing the wrong code path and crashes. Use
++  # check_symbol_exists instead.
++  check_symbol_exists(TIFFFieldReadCount "tiffio.h" ITK_TIFF_HAS_TIFFFieldReadCount)
+   check_type_size(TIFFField*  ITK_TIFF_HAS_TIFFField)
+ else()
+   set(ITKTIFF_INCLUDE_DIRS
+-- 
+2.39.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,9 +7,11 @@ package:
 source:
   url: https://github.com/InsightSoftwareConsortium/ITK/archive/v{{ version }}.tar.gz
   sha256: cf28bc7220c57c24ebcbabbd3b2544ea7ab65f0aad430a99f8e157738ed812b7
+  patches:
+    - 0001-BUG-use-check_symbol_exists-for-TIFFFieldReadCount.patch
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
## Summary

Applies the fix from upstream ITK PR [InsightSoftwareConsortium/ITK#6150](https://github.com/InsightSoftwareConsortium/ITK/pull/6150) as a recipe patch.

### Bug

When building with `ITK_USE_SYSTEM_TIFF=ON` (always the case in this feedstock), the CMake detection of `TIFFFieldReadCount` used `check_type_size()`, which internally calls `sizeof()` on the argument. Passing a **function** name to `sizeof()` is non-standard — GCC and Clang accept it as an extension, but MSVC rejects it — so `ITK_TIFF_HAS_TIFFFieldReadCount` was never defined on Windows builds.

Without that define, `itkTIFFImageIO` falls through to a libtiff 4.0.0–4.0.2 workaround that directly accesses the internal `_TIFFField` struct. That struct layout is no longer correct for modern libtiff versions, causing reads of garbage data and **NULL pointer crashes** when encountering tags with unsupported data types (e.g. an ICC profile tag).

Fixes: [InsightSoftwareConsortium/ITK#6148](https://github.com/InsightSoftwareConsortium/ITK/issues/6148)

### Fix

Replace `check_type_size(TIFFFieldReadCount ...)` with `check_symbol_exists(TIFFFieldReadCount "tiffio.h" ...)` in `Modules/ThirdParty/TIFF/CMakeLists.txt`, which correctly detects the function symbol on all compilers.

### Changes

- `recipe/0001-BUG-use-check_symbol_exists-for-TIFFFieldReadCount.patch` — new patch applying the upstream fix
- `recipe/meta.yaml` — add `patches:` list, bump build number 2 → 3
