### PR TITLE
Add libitk wrapping output

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,6 +29,15 @@ cmake -G "Ninja" ^
     -D "CMAKE_SYSTEM_PREFIX_PATH:PATH=%LIBRARY_PREFIX%" ^
     -D "CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%" ^
     -D CMAKE_BUILD_TYPE:STRING=RELEASE ^
+    -D ITK_WRAP_PYTHON:BOOL=ON ^
+    -D ITK_USE_SYSTEM_CASTXML:BOOL=ON ^
+    -D WRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWrapping ^
+    -D Python3_EXECUTABLE:FILEPATH="%PYTHON%" ^
+    -D ITK_WRAP_unsigned_short:BOOL=ON ^
+    -D ITK_WRAP_double:BOOL=ON ^
+    -D ITK_WRAP_complex_double:BOOL=ON ^
+    -D ITK_WRAP_IMAGE_DIMS:STRING="2;3;4" ^
+    -D PY_SITE_PACKAGES_PATH:PATH="Lib/site-packages" ^
     "%SRC_DIR%"
 
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -63,6 +63,15 @@ cmake \
     -D "CMAKE_FIND_APPBUNDLE:STRING=NEVER" \
     -D "CMAKE_INSTALL_PREFIX=${PREFIX}" \
     -D "CMAKE_PROGRAM_PATH=${BUILD_PREFIX}" \
+    -D ITK_WRAP_PYTHON:BOOL=ON \
+    -D ITK_USE_SYSTEM_CASTXML:BOOL=ON \
+    -D WRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWrapping \
+    -D Python3_EXECUTABLE:FILEPATH="${PYTHON}" \
+    -D ITK_WRAP_unsigned_short:BOOL=ON \
+    -D ITK_WRAP_double:BOOL=ON \
+    -D ITK_WRAP_complex_double:BOOL=ON \
+    -D ITK_WRAP_IMAGE_DIMS:STRING="2;3;4" \
+    -D PY_SITE_PACKAGES_PATH:PATH="lib/python${PY_VER}/site-packages" \
     "${SRC_DIR}"
 
 cmake --build . --config Release -- -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,6 +21,11 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
     if [[ -f "$try_run_results" ]]; then
         CMAKE_ARGS="${CMAKE_ARGS} -C ${try_run_results}"
     fi
+    # Target-arch Python hints. find_package(Python3 Development.Module)
+    # otherwise introspects ${PYTHON} (BUILD x86_64 headers) which
+    # CMAKE_FIND_ROOT_PATH=${PREFIX} then filters out.
+    CMAKE_ARGS="${CMAKE_ARGS} -DPython3_INCLUDE_DIR:PATH=${PREFIX}/include/python${PY_VER}"
+    CMAKE_ARGS="${CMAKE_ARGS} -DPython3_LIBRARY:FILEPATH=${PREFIX}/lib/libpython${PY_VER}.so"
 fi
 
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,14 @@ if [ "$(uname)" == "Darwin" ]; then
    use_tbb=OFF
 fi
 
+# Skip Python wrapping on linux-ppc64le: castxml's bundled Clang can't parse
+# PowerPC's __float128/__ieee128 (used by libstdc++ <limits>) or Eigen's
+# AltiVec PacketMath. Neither PyPI itk nor conda-forge itk ship for ppc64le.
+itk_wrap_python=ON
+if [ "${target_platform}" == "linux-ppc64le" ]; then
+    itk_wrap_python=OFF
+fi
+
 
 BUILD_DIR=${SRC_DIR}/build
 mkdir ${BUILD_DIR}
@@ -71,7 +79,7 @@ cmake \
     -D "CMAKE_FIND_APPBUNDLE:STRING=NEVER" \
     -D "CMAKE_INSTALL_PREFIX=${PREFIX}" \
     -D "CMAKE_PROGRAM_PATH=${BUILD_PREFIX}" \
-    -D ITK_WRAP_PYTHON:BOOL=ON \
+    -D ITK_WRAP_PYTHON:BOOL=${itk_wrap_python} \
     -D ITK_USE_SYSTEM_CASTXML:BOOL=ON \
     -D WRAP_ITK_INSTALL_COMPONENT_IDENTIFIER:STRING=PythonWrapping \
     -D Python3_EXECUTABLE:FILEPATH="${PYTHON}" \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,6 +26,9 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
     # CMAKE_FIND_ROOT_PATH=${PREFIX} then filters out.
     CMAKE_ARGS="${CMAKE_ARGS} -DPython3_INCLUDE_DIR:PATH=${PREFIX}/include/python${PY_VER}"
     CMAKE_ARGS="${CMAKE_ARGS} -DPython3_LIBRARY:FILEPATH=${PREFIX}/lib/libpython${PY_VER}.so"
+    # Castxml (Clang-based) needs an explicit target triple under cross-compile;
+    # ITK's wrapping reads CMAKE_CXX_COMPILER_TARGET in itk_auto_load_submodules.cmake.
+    CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_COMPILER_TARGET=${HOST}"
 fi
 
 

--- a/recipe/libitk-devel_install.bat
+++ b/recipe/libitk-devel_install.bat
@@ -4,3 +4,23 @@ cmake -DCOMPONENT=DebugDevel -P %BUILD_DIR%\cmake_install.cmake
 cmake -DCOMPONENT=cpplibraries  -P %BUILD_DIR%\cmake_install.cmake
 cmake -DCOMPONENT=Headers -P %BUILD_DIR%\cmake_install.cmake
 
+for /f "tokens=1,2 delims=." %%a in ("%PKG_VERSION%") do set ITK_VERSION_MM=%%a.%%b
+set ITK_CMAKE_DEST=%LIBRARY_PREFIX%\lib\cmake\ITK-%ITK_VERSION_MM%
+set KWSTYLE_DEST=%LIBRARY_PREFIX%\lib\cmake\Utilities\KWStyle
+if not exist "%ITK_CMAKE_DEST%" mkdir "%ITK_CMAKE_DEST%"
+if not exist "%KWSTYLE_DEST%" mkdir "%KWSTYLE_DEST%"
+REM Single-line set: cmd.exe's multi-line `for %%f in (^ ... ^)` is fragile,
+REM as caret continuations across many lines can drop entries or fail to parse.
+for %%f in (ITKModuleExternal.cmake ITKModuleMacros.cmake ITKModuleDoxygen.cmake ITKModuleHeaderTest.cmake ITKModuleKWStyleTest.cmake ITKModuleCPPCheckTest.cmake ITKModuleTest.cmake ITKExternalData.cmake ITKDownloadSetup.cmake ITKInitializeBuildType.cmake ExternalData.cmake ExternalData_config.cmake.in ITKModuleInfo.cmake.in ITKKWStyleConfig.cmake.in CppcheckTargets.cmake TopologicalSort.cmake) do (
+    copy /Y "%SRC_DIR%\CMake\%%f" "%ITK_CMAKE_DEST%\%%f"
+    if errorlevel 1 exit 1
+)
+copy /Y "%SRC_DIR%\Utilities\KWStyle\BuildKWStyle.cmake" "%KWSTYLE_DEST%\BuildKWStyle.cmake"
+if errorlevel 1 exit 1
+copy /Y "%SRC_DIR%\Utilities\KWStyle\KWStyle.cmake" "%KWSTYLE_DEST%\KWStyle.cmake"
+if errorlevel 1 exit 1
+
+set MAINT_DEST=%LIBRARY_PREFIX%\lib\cmake\Utilities\Maintenance
+if not exist "%MAINT_DEST%" mkdir "%MAINT_DEST%"
+copy /Y "%SRC_DIR%\Utilities\Maintenance\BuildHeaderTest.py" "%MAINT_DEST%\BuildHeaderTest.py"
+if errorlevel 1 exit 1

--- a/recipe/libitk-devel_install.sh
+++ b/recipe/libitk-devel_install.sh
@@ -1,3 +1,44 @@
 BUILD_DIR=${SRC_DIR}/build
 cmake -DCOMPONENT=Development -P ${BUILD_DIR}/cmake_install.cmake
 cmake -DCOMPONENT=Headers -P ${BUILD_DIR}/cmake_install.cmake
+
+# CMake module-build helpers not installed by upstream ITK's Development /
+# Headers components. Required for external (remote-module) projects to
+# find_package(ITK) and include(ITKModuleExternal).
+ITK_VERSION_MM=$(echo "${PKG_VERSION}" | awk -F. '{print $1"."$2}')
+ITK_CMAKE_DEST="${PREFIX}/lib/cmake/ITK-${ITK_VERSION_MM}"
+KWSTYLE_DEST="${PREFIX}/lib/cmake/Utilities/KWStyle"
+mkdir -p "${ITK_CMAKE_DEST}"
+mkdir -p "${KWSTYLE_DEST}"
+for f in \
+    ITKModuleExternal.cmake \
+    ITKModuleMacros.cmake \
+    ITKModuleDoxygen.cmake \
+    ITKModuleHeaderTest.cmake \
+    ITKModuleKWStyleTest.cmake \
+    ITKModuleCPPCheckTest.cmake \
+    ITKModuleTest.cmake \
+    ITKExternalData.cmake \
+    ITKDownloadSetup.cmake \
+    ITKInitializeBuildType.cmake \
+    ExternalData.cmake \
+    ExternalData_config.cmake.in \
+    ITKModuleInfo.cmake.in \
+    ITKKWStyleConfig.cmake.in \
+    CppcheckTargets.cmake \
+    TopologicalSort.cmake
+do
+    cp "${SRC_DIR}/CMake/${f}" "${ITK_CMAKE_DEST}/${f}"
+done
+
+# ITKModuleKWStyleTest.cmake unconditionally includes
+# ${ITK_CMAKE_DIR}/../Utilities/KWStyle/BuildKWStyle.cmake, so it has to be on
+# disk even when KWStyle itself isn't available.
+cp "${SRC_DIR}/Utilities/KWStyle/BuildKWStyle.cmake" "${KWSTYLE_DEST}/BuildKWStyle.cmake"
+cp "${SRC_DIR}/Utilities/KWStyle/KWStyle.cmake"      "${KWSTYLE_DEST}/KWStyle.cmake"
+
+# itk_module_test invokes BuildHeaderTest.py via the same ${ITK_CMAKE_DIR}/../
+# path convention.
+MAINT_DEST="${PREFIX}/lib/cmake/Utilities/Maintenance"
+mkdir -p "${MAINT_DEST}"
+cp "${SRC_DIR}/Utilities/Maintenance/BuildHeaderTest.py" "${MAINT_DEST}/BuildHeaderTest.py"

--- a/recipe/libitk-wrapping-devel_install.bat
+++ b/recipe/libitk-wrapping-devel_install.bat
@@ -1,0 +1,71 @@
+set BUILD_DIR=%SRC_DIR%\bld
+for /f "tokens=1,2 delims=." %%a in ("%PKG_VERSION%") do set ITK_VERSION_MM=%%a.%%b
+set ITK_CMAKE_DEST=%LIBRARY_PREFIX%\lib\cmake\ITK-%ITK_VERSION_MM%
+set WRAP_CMAKE_DEST=%LIBRARY_PREFIX%\lib\cmake\Wrapping
+set TYPEDEFS_DEST=%ITK_CMAKE_DEST%\Wrapping\Typedefs
+set INCLUDE_DEST=%LIBRARY_PREFIX%\include\ITK-%ITK_VERSION_MM%
+
+if not exist "%ITK_CMAKE_DEST%" mkdir "%ITK_CMAKE_DEST%"
+if not exist "%WRAP_CMAKE_DEST%" mkdir "%WRAP_CMAKE_DEST%"
+
+copy /Y "%SRC_DIR%\CMake\WrappingConfigCommon.cmake" "%ITK_CMAKE_DEST%\WrappingConfigCommon.cmake"
+if errorlevel 1 exit 1
+copy /Y "%SRC_DIR%\CMake\ITKSetPython3Vars.cmake" "%ITK_CMAKE_DEST%\ITKSetPython3Vars.cmake"
+if errorlevel 1 exit 1
+
+xcopy /E /I /Y "%SRC_DIR%\Wrapping" "%WRAP_CMAKE_DEST%"
+if errorlevel 1 exit 1
+
+REM Per-module wrapping/ subdirs (recursive find). `dir /b /s /AD wrapping`
+REM is more reliable than `for /d /r ... in (wrapping)` for matching literal
+REM directory names.
+pushd "%SRC_DIR%\Modules"
+setlocal enabledelayedexpansion
+for /f "delims=" %%d in ('dir /b /s /AD wrapping 2^>nul') do (
+    set "_src=%%d"
+    set "_rel=!_src:%SRC_DIR%\=!"
+    if not exist "%INCLUDE_DEST%\!_rel!" mkdir "%INCLUDE_DEST%\!_rel!"
+    xcopy /E /I /Y "!_src!" "%INCLUDE_DEST%\!_rel!"
+)
+endlocal
+popd
+
+REM Every module's itk-module.cmake. Downstream wheel-build tooling
+REM (ITKPythonPackage_BuildWheels.cmake) reads the source-tree layout
+REM Modules/<Group>/<Module>/itk-module.cmake to derive ITK_MODULE_<M>_GROUP.
+REM Group info is encoded purely by directory structure.
+pushd "%SRC_DIR%\Modules"
+setlocal enabledelayedexpansion
+for /f "delims=" %%f in ('dir /b /s itk-module.cmake 2^>nul') do (
+    set "_src=%%f"
+    set "_rel=!_src:%SRC_DIR%\=!"
+    for %%p in ("!_rel!") do set "_rel_dir=%%~dpp"
+    if not exist "%INCLUDE_DEST%\!_rel_dir!" mkdir "%INCLUDE_DEST%\!_rel_dir!"
+    copy /Y "!_src!" "%INCLUDE_DEST%\!_rel!"
+)
+endlocal
+popd
+
+REM Build-tree wrapping artifacts (.i, .idx, .mdx, pyBase.i, python/*_ext.i)
+REM not installed by upstream ITK. Required by SWIG at consumer build time.
+if not exist "%TYPEDEFS_DEST%" mkdir "%TYPEDEFS_DEST%"
+xcopy /E /I /Y "%BUILD_DIR%\Wrapping\Typedefs" "%TYPEDEFS_DEST%"
+
+REM Append Eigen3 + module-include hook to WrappingConfigCommon.cmake.
+REM See libitk-wrapping-devel_install.sh for the rationale.
+set "WRAP_CFG=%ITK_CMAKE_DEST%\WrappingConfigCommon.cmake"
+if exist "%WRAP_CFG%" (
+    >>"%WRAP_CFG%" echo.
+    >>"%WRAP_CFG%" echo # Forward Eigen3 + module includes for the wrapping/castxml pass.
+    >>"%WRAP_CFG%" echo if^(TARGET Eigen3::Eigen^)
+    >>"%WRAP_CFG%" echo   get_target_property^(_libitk_wrap_eigen_incs Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES^)
+    >>"%WRAP_CFG%" echo   if^(_libitk_wrap_eigen_incs^)
+    >>"%WRAP_CFG%" echo     include_directories^(${_libitk_wrap_eigen_incs}^)
+    >>"%WRAP_CFG%" echo   endif^(^)
+    >>"%WRAP_CFG%" echo   unset^(_libitk_wrap_eigen_incs^)
+    >>"%WRAP_CFG%" echo endif^(^)
+    >>"%WRAP_CFG%" echo if^(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include"^)
+    >>"%WRAP_CFG%" echo   include_directories^("${CMAKE_CURRENT_SOURCE_DIR}/include"^)
+    >>"%WRAP_CFG%" echo endif^(^)
+    >>"%WRAP_CFG%" echo include_directories^("${CMAKE_CURRENT_BINARY_DIR}/include"^)
+)

--- a/recipe/libitk-wrapping-devel_install.sh
+++ b/recipe/libitk-wrapping-devel_install.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+BUILD_DIR=${SRC_DIR}/build
+ITK_VERSION_MM=$(echo "${PKG_VERSION}" | awk -F. '{print $1"."$2}')
+ITK_CMAKE_DEST="${PREFIX}/lib/cmake/ITK-${ITK_VERSION_MM}"
+WRAP_CMAKE_DEST="${PREFIX}/lib/cmake/Wrapping"
+TYPEDEFS_DEST="${ITK_CMAKE_DEST}/Wrapping/Typedefs"
+INCLUDE_DEST="${PREFIX}/include/ITK-${ITK_VERSION_MM}"
+
+mkdir -p "${ITK_CMAKE_DEST}"
+mkdir -p "${WRAP_CMAKE_DEST}"
+
+# Wrapping CMake helpers that ITKModuleExternal.cmake includes by name.
+cp "${SRC_DIR}/CMake/WrappingConfigCommon.cmake" "${ITK_CMAKE_DEST}/WrappingConfigCommon.cmake"
+cp "${SRC_DIR}/CMake/ITKSetPython3Vars.cmake"     "${ITK_CMAKE_DEST}/ITKSetPython3Vars.cmake"
+
+# Full Wrapping/ source tree. ITKModuleExternal.cmake sets
+# WRAP_ITK_CMAKE_DIR = ${ITK_CMAKE_DIR}/../Wrapping, which resolves to this
+# location given ITK_CMAKE_DIR = ${ITK_CMAKE_DEST}.
+cp -R "${SRC_DIR}/Wrapping/." "${WRAP_CMAKE_DEST}/"
+
+# Per-module wrapping/ subdirs (Modules/<Group>/<Module>/wrapping/) so that
+# external builds re-using ITK module sources can resolve .wrap dependencies.
+cd "${SRC_DIR}"
+while IFS= read -r wrap_src; do
+    rel="${wrap_src#./}"           # e.g. Modules/Core/Common/wrapping
+    dest="${INCLUDE_DEST}/${rel}"
+    mkdir -p "${dest}"
+    cp -R "${wrap_src}/." "${dest}/"
+done < <(find Modules -type d -name wrapping)
+
+# Every module's itk-module.cmake. Downstream wheel-build tooling derives
+# ITK_MODULE_<M>_GROUP from the directory layout, so the file location matters.
+# Ship all of them (including ThirdParty) since the dependency walk reads GROUP
+# for non-wrapped deps too.
+while IFS= read -r module_cmake; do
+    rel="${module_cmake#./}"       # e.g. Modules/Core/Common/itk-module.cmake
+    dest_dir="${INCLUDE_DEST}/$(dirname "${rel}")"
+    mkdir -p "${dest_dir}"
+    cp "${module_cmake}" "${dest_dir}/itk-module.cmake"
+done < <(find Modules -name itk-module.cmake)
+
+# Build-tree wrapping artifacts (.i, .idx, .mdx, pyBase.i, python/*_ext.i) that
+# upstream ITK doesn't install. Required at ${ITK_CMAKE_DIR}/Wrapping/Typedefs/
+# for consumer SWIG runs to resolve %import "pyBase.i" and .mdx dependencies.
+mkdir -p "${TYPEDEFS_DEST}"
+cp -R "${BUILD_DIR}/Wrapping/Typedefs/." "${TYPEDEFS_DEST}/"
+
+# Append Eigen3 + module-include hook to the installed WrappingConfigCommon.cmake.
+WRAP_CFG="${ITK_CMAKE_DEST}/WrappingConfigCommon.cmake"
+if [[ -f "${WRAP_CFG}" ]]; then
+    cat >> "${WRAP_CFG}" <<'EOF'
+
+# Added by libitk-feedstock: castxml's include set comes from
+# get_directory_property(... INCLUDE_DIRECTORIES), which doesn't pick up
+# target-only includes (Eigen3::Eigen) or the consumer module's own include/
+# dirs. Push them onto the directory property here.
+if(TARGET Eigen3::Eigen)
+  get_target_property(_libitk_wrap_eigen_incs
+    Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
+  if(_libitk_wrap_eigen_incs)
+    include_directories(${_libitk_wrap_eigen_incs})
+  endif()
+  unset(_libitk_wrap_eigen_incs)
+endif()
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
+endif()
+# Binary include/ for generate_export_header outputs; the dir is created
+# during the build before castxml runs.
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
+EOF
+fi

--- a/recipe/libitk-wrapping_install.bat
+++ b/recipe/libitk-wrapping_install.bat
@@ -1,0 +1,24 @@
+set BUILD_DIR=%SRC_DIR%\bld
+
+REM Sweep all components that may carry wrapping payload, then prune.
+for %%c in (PythonWrappingRuntimeLibraries Runtime RuntimeLibraries Libraries Unspecified libraries) do (
+    cmake -DCOMPONENT=%%c -P %BUILD_DIR%\cmake_install.cmake
+)
+
+REM Stash wrapping payload, wipe everything else, restore.
+set PYSITE=%LIBRARY_PREFIX%\Lib\site-packages
+set STASH=%TEMP%\libitk-wrapping-stash
+if exist "%STASH%" rmdir /S /Q "%STASH%"
+mkdir "%STASH%"
+if exist "%PYSITE%\itk"          move "%PYSITE%\itk"          "%STASH%\itk"
+if exist "%PYSITE%\itkConfig.py" move "%PYSITE%\itkConfig.py" "%STASH%\itkConfig.py"
+
+if exist "%LIBRARY_PREFIX%\Lib"     rmdir /S /Q "%LIBRARY_PREFIX%\Lib"
+if exist "%LIBRARY_PREFIX%\bin"     rmdir /S /Q "%LIBRARY_PREFIX%\bin"
+if exist "%LIBRARY_PREFIX%\include" rmdir /S /Q "%LIBRARY_PREFIX%\include"
+if exist "%LIBRARY_PREFIX%\share"   rmdir /S /Q "%LIBRARY_PREFIX%\share"
+
+mkdir "%PYSITE%"
+if exist "%STASH%\itk"          move "%STASH%\itk"          "%PYSITE%\itk"
+if exist "%STASH%\itkConfig.py" move "%STASH%\itkConfig.py" "%PYSITE%\itkConfig.py"
+rmdir /Q "%STASH%" 2>nul

--- a/recipe/libitk-wrapping_install.sh
+++ b/recipe/libitk-wrapping_install.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+BUILD_DIR=${SRC_DIR}/build
+
+# ITK's wrapping install rules don't cleanly partition by COMPONENT, so a
+# narrow `cmake -DCOMPONENT=PythonWrappingRuntimeLibraries` install only
+# installs itkConfig.py. Include all components that may carry wrapping payload
+# into our prefix, then prune to keep only the Python wrapping content.
+for component in PythonWrappingRuntimeLibraries Runtime RuntimeLibraries Libraries Unspecified libraries; do
+    cmake -DCOMPONENT="${component}" -P "${BUILD_DIR}/cmake_install.cmake" || true
+done
+
+# The canonical site-packages path for this Python.
+PYSITE="${PREFIX}/lib/python${PY_VER}/site-packages"
+
+# Some ITK / conda-build interactions land the wrapping payload at a
+# truncated path (e.g. lib/python3.1 instead of lib/python3.12 for PY_VER=3.12)
+# despite the -D PY_SITE_PACKAGES_PATH override. If the glob finds anything
+# under a *different* python<X>/site-packages dir, relocate it to the
+# canonical PYSITE before the prune step runs.
+#
+# Skip symlinked python<X> dirs: conda's python package ships e.g.
+# `lib/python3.1 -> python3.12` as a compat alias, so the glob matches both
+# but they reference the same physical directory.
+for candidate in "${PREFIX}"/lib/python*/site-packages; do
+    [ -d "${candidate}" ] || continue
+    parent="$(dirname "${candidate}")"
+    if [ -L "${parent}" ]; then
+        echo "Skipping ${candidate} (parent is symlink: $(readlink "${parent}"))"
+        continue
+    fi
+    if [ "${candidate}" != "${PYSITE}" ]; then
+        echo "Relocating wrapping payload from ${candidate} to ${PYSITE}"
+        mkdir -p "$(dirname "${PYSITE}")"
+        if [ -d "${PYSITE}" ]; then
+            cp -R "${candidate}/." "${PYSITE}/"
+            rm -rf "${candidate}"
+        else
+            mv "${candidate}" "${PYSITE}"
+        fi
+        rmdir "${parent}" 2>/dev/null || true
+    fi
+done
+
+if [ ! -d "${PYSITE}" ]; then
+    echo "ERROR: no site-packages content at ${PYSITE}" >&2
+    exit 1
+fi
+
+# Stash the wrapping payload, wipe everything else, restore.
+TMP=$(mktemp -d)
+[ -d "${PYSITE}/itk" ]          && mv "${PYSITE}/itk"          "${TMP}/"
+[ -f "${PYSITE}/itkConfig.py" ] && mv "${PYSITE}/itkConfig.py" "${TMP}/"
+
+rm -rf "${PREFIX}/lib" "${PREFIX}/bin" "${PREFIX}/include" "${PREFIX}/share"
+
+mkdir -p "${PYSITE}"
+[ -d "${TMP}/itk" ]          && mv "${TMP}/itk"          "${PYSITE}/"
+[ -f "${TMP}/itkConfig.py" ] && mv "${TMP}/itkConfig.py" "${PYSITE}/"
+rmdir "${TMP}" 2>/dev/null || true

--- a/recipe/libitk_install.bat
+++ b/recipe/libitk_install.bat
@@ -4,3 +4,9 @@ cmake -DCOMPONENT=RuntimeLibraries -P %BUILD_DIR%\cmake_install.cmake
 cmake -DCOMPONENT=Libraries -P %BUILD_DIR%\cmake_install.cmake
 cmake -DCOMPONENT=Unspecified -P %BUILD_DIR%\cmake_install.cmake
 cmake -DCOMPONENT=libraries -P %BUILD_DIR%\cmake_install.cmake
+
+REM Evict Python wrapping payload from libitk; it belongs in libitk-wrapping.
+for /d %%P in ("%LIBRARY_PREFIX%\Lib\site-packages\itk") do (
+    if exist "%%P" rmdir /S /Q "%%P"
+)
+if exist "%LIBRARY_PREFIX%\Lib\site-packages\itkConfig.py" del /Q "%LIBRARY_PREFIX%\Lib\site-packages\itkConfig.py"

--- a/recipe/libitk_install.sh
+++ b/recipe/libitk_install.sh
@@ -1,5 +1,13 @@
 BUILD_DIR=${SRC_DIR}/build
 components="Runtime RuntimeLibraries Libraries Unspecified libraries"
-for component in ${components}; do 
+for component in ${components}; do
     cmake -DCOMPONENT=${component} -P ${BUILD_DIR}/cmake_install.cmake
 done
+
+# ITK's wrapping install rules don't partition cleanly by COMPONENT: pieces of
+# the Python payload land in Unspecified / libraries even with
+# WRAP_ITK_INSTALL_COMPONENT_IDENTIFIER set. Drop them so libitk-wrapping
+# can claim them.
+rm -rf "${PREFIX}"/lib/python*/site-packages/itk
+rm -f  "${PREFIX}"/lib/python*/site-packages/itkConfig.py
+rm -f  "${PREFIX}"/lib/python*/site-packages/__pycache__/itkConfig*.pyc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,6 +95,8 @@ outputs:
 
   # libitk-wrapping has no run_exports: Python consumers depend on it directly.
   - name: libitk-wrapping
+    build:
+      skip: true  # [linux and ppc64le]
     script: libitk-wrapping_install.sh  # [not win]
     script: libitk-wrapping_install.bat  # [win]
     requirements:
@@ -118,6 +120,8 @@ outputs:
   # .wrap files) needed to build Python-wrapped remote modules against an
   # installed ITK.
   - name: libitk-wrapping-devel
+    build:
+      skip: true  # [linux and ppc64le]
     script: libitk-wrapping-devel_install.sh  # [not win]
     script: libitk-wrapping-devel_install.bat  # [win]
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "5.4.6" %}
+{% set itk_dir = "ITK-" + '.'.join(version.split('.')[:2]) %}
 
 package:
   name: libitk
@@ -106,6 +107,31 @@ outputs:
         - numpy
       imports:
         - itk
+
+  # Wrapping infrastructure (CMake helpers + Wrapping/ source tree + per-module
+  # .wrap files) needed to build Python-wrapped remote modules against an
+  # installed ITK.
+  - name: libitk-wrapping-devel
+    script: libitk-wrapping-devel_install.sh  # [not win]
+    script: libitk-wrapping-devel_install.bat  # [win]
+    requirements:
+      host:
+        - python
+        - {{ pin_subpackage("libitk", exact=True) }}
+      run:
+        - {{ pin_subpackage("libitk-devel", exact=True) }}
+        - {{ pin_subpackage("libitk-wrapping", exact=True) }}
+        - swig
+        - castxml
+        - pygccxml
+    test:
+      commands:
+        - test -f $PREFIX/lib/cmake/Wrapping/CMakeLists.txt              # [not win]
+        - test -f $PREFIX/lib/cmake/{{ itk_dir }}/WrappingConfigCommon.cmake   # [not win]
+        - test -f $PREFIX/lib/cmake/{{ itk_dir }}/ITKModuleExternal.cmake      # [not win]
+        - if not exist %LIBRARY_PREFIX%\\lib\\cmake\\Wrapping\\CMakeLists.txt exit 1            # [win]
+        - if not exist %LIBRARY_PREFIX%\\lib\\cmake\\{{ itk_dir }}\\WrappingConfigCommon.cmake exit 1 # [win]
+        - if not exist %LIBRARY_PREFIX%\\lib\\cmake\\{{ itk_dir }}\\ITKModuleExternal.cmake exit 1    # [win]
 
 about:
   home: http://www.itk.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,6 +75,10 @@ outputs:
       run:
         - {{ pin_subpackage("libitk", exact=True) }}
         - tbb-devel
+        # ITK headers have `#include <Eigen/...>` (ITK_USE_SYSTEM_EIGEN=ON),
+        # so consumers compiling against libitk-devel need Eigen on the
+        # include path.
+        - eigen
 
     test:
       requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
     - 0001-BUG-use-check_symbol_exists-for-TIFFFieldReadCount.patch
 
 build:
-  number: 4
+  number: 5
   skip: true  # [win and vc<14]
 
 requirements:
@@ -21,6 +21,9 @@ requirements:
     - {{ compiler('c') }}
     - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - castxml
   host:
     - expat                     # [not win]
     - fftw
@@ -31,6 +34,7 @@ requirements:
     - eigen
     - zlib                      # [not win]
     - tbb-devel
+    - python
 
 outputs:
   - name: libitk
@@ -83,6 +87,25 @@ outputs:
         - cmake -G Ninja -D "CMAKE_SYSTEM_PREFIX_PATH:FILEPATH=${PREFIX}" ./example  # [not win]
         - cmake -G Ninja -D "CMAKE_SYSTEM_PREFIX_PATH:FILEPATH=%PREFIX%" -D CMAKE_BUILD_TYPE:STRING=RELEASE example     # [win]
         - cmake --build . --config Release
+
+  # libitk-wrapping has no run_exports: Python consumers depend on it directly.
+  - name: libitk-wrapping
+    script: libitk-wrapping_install.sh  # [not win]
+    script: libitk-wrapping_install.bat  # [win]
+    requirements:
+      host:
+        - python
+        - {{ pin_subpackage("libitk", exact=True) }}
+      run:
+        - python
+        - numpy
+        - {{ pin_subpackage("libitk", exact=True) }}
+    test:
+      requires:
+        - python {{ python }}
+        - numpy
+      imports:
+        - itk
 
 about:
   home: http://www.itk.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,6 +94,8 @@ outputs:
     script: libitk-wrapping_install.sh  # [not win]
     script: libitk-wrapping_install.bat  # [win]
     requirements:
+      build:
+        - cmake
       host:
         - python
         - {{ pin_subpackage("libitk", exact=True) }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

## Purpose

The purpose of this PR is to add a wrapping output to libitk conda packaging (discussed in [ITKPythonPackage PR #302](https://github.com/InsightSoftwareConsortium/ITKPythonPackage/pull/302)). This allows ITK remote modules to be packages as conda packages usable in Python conda environments.

I also experimented with using these conda packages as caches for building Python wheels for ITK. While this worked for mac and windows builds, to make manylinux compatible wheels, I believe the conda packages would need to be created within the manylinux docker environments with the correct compilers and toolchains (which may not be possible here). 

> [!NOTE]                                                                                                                                                                                                                
> Only one Python version is built per platform variant. 
> Expanding to multiple Python versions (e.g. 3.10, 3.11, 3.12) is a follow-up decisions as it multiplies CI time, and the supported version set hasn't been agreed on yet.